### PR TITLE
fix: modify producer config for SCRAM

### DIFF
--- a/producer.config
+++ b/producer.config
@@ -13,7 +13,8 @@ bootstrap.servers=
 # ssl.truststore.password=
 
 # SCRAM SHA 512 CREDENTIALS (if SCRAM SHA 512 is enabled)
-# security.protocol=SSL
+# security.protocol=SASL_SSL
+# ssl.protocol=TLSv1.2
 # sasl.mechanism=SCRAM-SHA-512
 # sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="" password="";
 


### PR DESCRIPTION
The producer config for SCRAM auth was incorrect. This PR fixes that.

Signed-off-by: Stelios Gkiokas <Stylianos.Gkiokas@ibm.com>