### PR TITLE
Add missing config for ES 2019.4.2 and earlier

### DIFF
--- a/producer.config
+++ b/producer.config
@@ -25,6 +25,7 @@ bootstrap.servers=
 # ssl.keystore.password=
 
 # SASL PLAIN CREDENTIALS (only for Event Streams 2019.4.2 and earlier)
+# sasl.mechanism=PLAIN
 # security.protocol=SASL_SSL
 # sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="token" password="";
 


### PR DESCRIPTION
Bug:
Without the`sasl.mechanism` flag the producer application fails to initialize with the exception: `No serviceName defined in either JAAS or Kafka config`

Fix:
Add the missing flag into the sample config file.